### PR TITLE
New feature: create blog pages from Markdown instead of HTML like normal posts

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -1,0 +1,8 @@
+---
+title: About
+date: 2017-11-14
+description: A sample about page.
+ispage: yes
+...
+
+This is a sample about page.

--- a/readme.md
+++ b/readme.md
@@ -66,8 +66,15 @@ For deploying athena to a remove server read the relevant section below.
 
 ### Post structure
 
-athena reads Markdown files from the `pages/` directory and builds static HTML
-files. Posts must start with the following YAML structure:
+athena supports two types of Markdown-to-HTML content: posts and pages.
+`posts` are normal blog posts and `pages` are auxiliary to the blog pages such
+as _About_ or _Contact_. Both are read from the `pages/` directory and are
+subsequently built to static HTML files. The difference between a post and a
+page is one YAML key.
+
+**Posts**
+
+Posts must start with the following YAML structure:
 
     ---
     title: Title of the post
@@ -75,9 +82,31 @@ files. Posts must start with the following YAML structure:
     description: A short description of the post.
     ...
 
-Title and date values are extracted for the index loop and the post's
-permalink. Both the author and description values are used in the post's HTML
-meta tags and are optional. The name of the Markdown file can by anything.
+Posts are accessible in the following endpoint: `/posts/<name-of-post>`
+
+**Pages**
+
+Pages must start with the following YAML structure:
+
+    ---
+    title: Title of the page
+    date: 2017-11-14
+    description: A sample about page.
+    ispage: yes
+    ...
+
+Pages are accessible in the following endpoint: `/<name-of-page>`
+
+For both posts and pages: title and date values are extracted for the index
+loop and the post's permalink; the `ispage` value is filtered in the backend
+in order to produce a list of posts and a list of pages for the nav and side
+bars, as well as the Atom feed. Both author and description values are
+used in the post's HTML meta tags and are optional. The name of the Markdown
+file for either a post or a page can by anything and is its URL path.
+
+For instance: \
+`about.md` with `ispage: yes` will be available at `/about` \
+`random.md` without `ispage` at all will be available at `/posts/random`
 
 ### Tufte CSS-specific elements
 

--- a/templates/hard.html
+++ b/templates/hard.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <head>
   <meta charset="utf-8"/>
-  <title>About &mdash; {{ config.title }}</title>
+  <title>{{ page.title }} &mdash; {{ config.title }}</title>
   <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='tufte.css') }}">
   <script type="text/javascript" src="{{ url_for('static', filename='enquire.min.js') }}"></script>
   <script type="text/javascript" src="{{ url_for('static', filename='jquery-1.12.4.min.js') }}"></script>
@@ -13,17 +13,23 @@
 </head>
 <body>
  <div class="thearticle">
+
   <article>
-    <h1>About</h1>
-    <p><span id="blogdesc" class="marginnote">
-        {{ config.sidebardesc }}<br><br>
-        <a href="{{ url_for("index") }}">home</a> ·
-        <a href="{{ url_for("about") }}">about</a> ·
-        <a href="{{ url_for("recent_feed") }}">subscribe</a>
-      </span>
-    </p>
+    {% block content %}
+    <h1>{{ page.title }}</h1>
+    <p id="blog-p"><span id="blogdesc" class="marginnote">
+    {{ config.sidebardesc }}<br><br>
+    <a href="{{ url_for("index") }}">home</a> ·
+    {% for page in hpages %}
+      <a href="{{ url_for("hardpagelink", path=page.path)}}">
+        {{ page.title.lower() }}
+      </a> ·
+    {% endfor %}
+    <a href="{{ url_for("recent_feed") }}">subscribe</a></span></p>
+
     <section>
-      <p>This is a sample about page.</p>
+    {{ page.html|safe }}
+    {% endblock content %}
     </section>
   </article>
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,7 +26,13 @@
     <div class="navigation">
       <ul class="navigation-list">
         <li class="active"><a href="{{ url_for("index") }}">home</a> ·</li>
-        <li><a href="{{ url_for("about") }}">about</a> ·</li>
+        {% for page in hpages %}
+            <li>
+              <a href="{{ url_for("hardpagelink", path=page.path)}}">
+                {{ page.title.lower() }}
+              </a> ·
+            </li>
+         {% endfor %}
         <li><a href="{{ url_for("recent_feed") }}">subscribe</a></li>
       </ul>
     </div> <!-- navigation end -->

--- a/templates/page.html
+++ b/templates/page.html
@@ -36,7 +36,10 @@
     <p id="blog-p"><span id="blogdesc" class="marginnote">
     {{ config.sidebardesc }}<br><br>
     <a href="{{ url_for("index") }}">home</a> ·
-    <a href="{{ url_for("about") }}">about</a> ·
+    {% for page in hpages %}
+      <a href="{{ url_for("hardpagelink", path=page.path)}}">
+        {{ page.title.lower() }}</a> ·
+    {% endfor %}
     <a href="{{ url_for("recent_feed") }}">subscribe</a></span></p>
 
     <subtitle class="sub-date">{{ page.date.strftime('%B %d, %Y') }} · <span style="font-size: 1.6rem;"><a style="border-bottom-width: 0px !important;" href="{{ request.path }}">&infin;</a></span></subtitle>


### PR DESCRIPTION
athena can now render blog auxiliary (hard?) pages from Markdown and Pandoc. Previously, for pages like `About` it only supported a hardcoded HTML page along with its various template references; now it only needs a Markdown file in `pages/` directory with a specific `YAML` key and will generate both the content and the template references automatically.