### PR TITLE
Fix: appearance of side/margin notes on small screens

### DIFF
--- a/static/tufte.css
+++ b/static/tufte.css
@@ -350,7 +350,9 @@ label.sidenote-number { display: inline; }
 label.margin-toggle:not(.sidenote-number) { display: none; }
 
 @media(max-width: 760px) { label.margin-toggle:not(.sidenote-number) { display: inline; }
+                           figure .marginnote { display: inline; }
                            .sidenote, .marginnote { display: none; }
+                           .marginnote { float: none; }
                            img.mached { width: 41px; height: 54px;}
                            #blogdesc { width: 90%; display: block;}
                            .thefooter { width: 90% !important; }

--- a/static/tufte.css
+++ b/static/tufte.css
@@ -350,7 +350,7 @@ label.sidenote-number { display: inline; }
 label.margin-toggle:not(.sidenote-number) { display: none; }
 
 @media(max-width: 760px) { label.margin-toggle:not(.sidenote-number) { display: inline; }
-                           figure .marginnote { display: inline; }
+                           figure .marginnote, .figure .marginnote { display: inline; }
                            .sidenote, .marginnote { display: none; }
                            .marginnote { float: none; }
                            img.mached { width: 41px; height: 54px;}

--- a/static/tufte.css
+++ b/static/tufte.css
@@ -350,8 +350,7 @@ label.sidenote-number { display: inline; }
 label.margin-toggle:not(.sidenote-number) { display: none; }
 
 @media(max-width: 760px) { label.margin-toggle:not(.sidenote-number) { display: inline; }
-                           .sidenote { display: none; }
-                           .marginnote { float: none; }
+                           .sidenote, .marginnote { display: none; }
                            img.mached { width: 41px; height: 54px;}
                            #blogdesc { width: 90%; display: block;}
                            .thefooter { width: 90% !important; }
@@ -377,7 +376,8 @@ label.margin-toggle:not(.sidenote-number) { display: none; }
                                             vertical-align: baseline;
                                             position: relative; }
                            table, table.booktabs { width: 85%; }
-                           img { width: 100%; } }
+                           img { width: 100%; }
+                           p { overflow: hidden; }}
 
 /* amendments */
 


### PR DESCRIPTION
I recently discovered this project and it looks pretty nifty. I just noticed a couple of issues when for mobile devices specifically (small widths) that I've tried to fix:

- Margin notes are not hidden by default, unlike regular sidenotes (i.e. `.sidenote { display: none; }`). Seems like this is a mistake and not intentional? (The original Tufte CSS project hides them similarly to numbered sidenotes.) I simply expanded the selector to include margin notes as well.
- Both types of notes can flow into subsequent blocks, as shown in these images (from the demo pages). In the first image, expanding the margin note causes it to flow into the blockquote:
![ex1](https://user-images.githubusercontent.com/8396080/33249373-24217400-d2f8-11e7-8220-b8b284de65fa.png)
- In the second, expanding the sidenote causes it to shift the H1 heading to the right:
![ex2](https://user-images.githubusercontent.com/8396080/33249376-26050e08-d2f8-11e7-854f-b6f406067f79.png)

I believe this occurs since the notes are floating elements and can "escape" their parent block. I've resolved it by simply adding `overflow: hidden` to paragraphs (e.g. as seen [here](https://stackoverflow.com/questions/2062258/floating-elements-within-a-div-floats-outside-of-div-why)) on small screens.