### PR TITLE
Removed the bottom border of <a> in code blocks

### DIFF
--- a/static/tufte.css
+++ b/static/tufte.css
@@ -311,6 +311,10 @@ code { font-family: Menlo Regular;
         padding: 2px;
    }
 
+code a {
+  border-bottom: 0px;
+}
+
 .code { font-family: Menlo Regular, Consolas, "Liberation Mono", Menlo, Courier, monospace;
         color: #222; }
         /*font-size: 1.125rem;*/


### PR DESCRIPTION
The code block contains <a> tags and the are underlined with a border as they were links